### PR TITLE
Fixed the problem with retrieving user data from Slack

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 
 # Library versions
 lombokVersion = 1.16.18
-jbotVersion = 3.0.2
+jbotVersion = 4.1.0

--- a/src/main/java/com/vacation_bot/VacationBotApplication.java
+++ b/src/main/java/com/vacation_bot/VacationBotApplication.java
@@ -5,6 +5,8 @@ import com.vacation_bot.core.classification.ClassificationService;
 import com.vacation_bot.core.customization.CustomizationService;
 import com.vacation_bot.core.process.RegisterVacationService;
 import com.vacation_bot.core.process.RequestDaysLeftService;
+import com.vacation_bot.core.services.UserPort;
+import com.vacation_bot.core.services.UserService;
 import com.vacation_bot.core.words.WordsService;
 import com.vacation_bot.repositories.DefaultRepositoryFactory;
 import com.vacation_bot.repositories.RepositoryFactory;
@@ -23,6 +25,8 @@ import org.springframework.data.mongodb.core.ScriptOperations;
 import org.springframework.data.mongodb.core.script.ExecutableMongoScript;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+import org.springframework.web.client.RestOperations;
+import org.springframework.web.client.RestTemplate;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -52,8 +56,18 @@ public class VacationBotApplication {
 	}
 
 	@Bean
-	DefaultRepositoryFactory repositoryFactory( List<MongoRepository> repositories ) {
+	public RestOperations restTemplate() {
+		return new RestTemplate();
+	}
+
+	@Bean
+	public DefaultRepositoryFactory repositoryFactory( List<MongoRepository> repositories ) {
 		return new DefaultRepositoryFactory( repositories );
+	}
+
+	@Bean
+	public UserPort userPort( RepositoryFactory repositoryFactory ) {
+		return new UserService( repositoryFactory );
 	}
 
 	@Bean
@@ -62,7 +76,7 @@ public class VacationBotApplication {
 	}
 
 	@Bean
-	WordsService wordsService( RepositoryFactory repositoryFactory ) {
+	public WordsService wordsService( RepositoryFactory repositoryFactory ) {
 		return new WordsService( repositoryFactory );
 	}
 

--- a/src/main/java/com/vacation_bot/core/process/RegisterVacationService.java
+++ b/src/main/java/com/vacation_bot/core/process/RegisterVacationService.java
@@ -15,6 +15,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Calendar;
 import java.util.UUID;
@@ -37,17 +38,18 @@ public class RegisterVacationService extends BaseService {
     String registerVacation( final CustomizedSentence customizedSentence ) {
         getLogger().info( VacationBotLoggingMessages.REGISTER_VACATION_CHAIN.getMessage() );
         //TODO add verification for a single name and two days. Days order?
-        LocalDate startDate = LocalDate.parse( customizedSentence.getDates().get( 0 ) );
-        LocalDate endDate = LocalDate.parse( customizedSentence.getDates().get( 1 ) );
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern( "dd.MM.yy" );
+        LocalDate startDate = LocalDate.parse( customizedSentence.getDates().get( 0 ), formatter );
+        LocalDate endDate = LocalDate.parse( customizedSentence.getDates().get( 1 ), formatter );
         String userName = customizedSentence.getPersons().isEmpty() ? customizedSentence.getUserExternalCode() : customizedSentence.getPersons().get( 0 );
         return createVacation( userName, startDate, endDate );
     }
 
     private String createVacation( final String userName, final LocalDate startDate, final LocalDate endDate ) {
         int currentYear = Calendar.getInstance().get( Calendar.YEAR );
-        int period = (int) ChronoUnit.DAYS.between( startDate, endDate );
+        int period = (int) ChronoUnit.DAYS.between( startDate, endDate ) + 1;
 
-        UserModel user = getUserModelRepository().findByNameOrAliases( userName, userName )
+        UserModel user = getUserModelRepository().findById( userName )
                 .orElseThrow( () -> new RepositoryException( SharedConstants.USER_NOT_FOUND_MESSAGE ) );
 
         final VacationTotalModel vacationTotal = getVacationTotalRepository().findByUserIdAndYear( user.getId(), currentYear );

--- a/src/main/java/com/vacation_bot/core/process/RequestDaysLeftService.java
+++ b/src/main/java/com/vacation_bot/core/process/RequestDaysLeftService.java
@@ -22,12 +22,12 @@ public class RequestDaysLeftService extends BaseService {
     }
 
     @ServiceActivator
-    String calcuateDaysLeft( final CustomizedSentence customizedSentence ) {
+    String calculateDaysLeft( final CustomizedSentence customizedSentence ) {
         getLogger().info( VacationBotLoggingMessages.DAYS_LEFT_CHAIN.getMessage() );
         //TODO Add validation of person names amount
         String userName = customizedSentence.getPersons().isEmpty() ? customizedSentence.getUserExternalCode() : customizedSentence.getPersons().get( 0 );
         int currentYear = Calendar.getInstance().get( Calendar.YEAR );
-        UserModel user = getUserModelRepository().findByNameOrAliases( userName, userName )
+        UserModel user = getUserModelRepository().findById( userName )
                 .orElseThrow( () -> new RepositoryException( SharedConstants.USER_NOT_FOUND_MESSAGE ) );
         VacationTotalModel vacationTotal = getVacationTotalRepository().findByUserIdAndYear( user.getId(), currentYear );
         String validDays = vacationTotal != null ? vacationTotal.getVacationTotal() + "" : "no";

--- a/src/main/java/com/vacation_bot/core/services/UserPort.java
+++ b/src/main/java/com/vacation_bot/core/services/UserPort.java
@@ -1,0 +1,15 @@
+package com.vacation_bot.core.services;
+
+import me.ramswaroop.jbot.core.slack.models.User;
+
+/**
+ * Responsible for managing user data.
+ */
+public interface UserPort {
+
+    /**
+     * Saves user to the system.
+     * @param user the user to save.
+     */
+    void save( final User user );
+}

--- a/src/main/java/com/vacation_bot/core/services/UserService.java
+++ b/src/main/java/com/vacation_bot/core/services/UserService.java
@@ -1,0 +1,25 @@
+package com.vacation_bot.core.services;
+
+import com.vacation_bot.core.BaseService;
+import com.vacation_bot.domain.models.UserModel;
+import com.vacation_bot.repositories.RepositoryFactory;
+import me.ramswaroop.jbot.core.slack.models.User;
+
+/**
+ * Responsible for managing user data.
+ */
+public class UserService extends BaseService implements UserPort {
+
+    public UserService( final RepositoryFactory factory ) {
+        super( factory );
+    }
+
+    @Override
+    public void save( final User user ) {
+        final UserModel userModel = new UserModel();
+        userModel.setId( user.getId() );
+        userModel.setName( user.getName() );
+        userModel.setEmail( user.getProfile().getEmail() );
+        getUserModelRepository().save( userModel );
+    }
+}

--- a/src/main/java/com/vacation_bot/domain/models/UserModel.java
+++ b/src/main/java/com/vacation_bot/domain/models/UserModel.java
@@ -4,7 +4,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
@@ -30,6 +30,7 @@ public class UserModel {
      * The user name.
      */
     @Field( FieldNames.NAME )
+    @Indexed
     private String name;
 
     /**
@@ -42,6 +43,7 @@ public class UserModel {
      * The user name aliases.
      */
     @Field( FieldNames.ALIASES )
+    @Indexed
     private List<String> aliases;
 
     public static final class FieldNames {

--- a/src/main/java/com/vacation_bot/gateway/inbound/slack/SlackBot.java
+++ b/src/main/java/com/vacation_bot/gateway/inbound/slack/SlackBot.java
@@ -1,12 +1,15 @@
 package com.vacation_bot.gateway.inbound.slack;
 
 import com.vacation_bot.core.InternalTranslationPort;
+import com.vacation_bot.core.services.UserPort;
 import com.vacation_bot.domain.CustomizedSentence;
+import com.vacation_bot.gateway.outbound.slack.SlackApiPort;
+import me.ramswaroop.jbot.core.common.Controller;
+import me.ramswaroop.jbot.core.common.EventType;
 import me.ramswaroop.jbot.core.slack.Bot;
-import me.ramswaroop.jbot.core.slack.Controller;
-import me.ramswaroop.jbot.core.slack.EventType;
 import me.ramswaroop.jbot.core.slack.models.Event;
 import me.ramswaroop.jbot.core.slack.models.Message;
+import me.ramswaroop.jbot.core.slack.models.User;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.stereotype.Component;
@@ -15,10 +18,25 @@ import org.springframework.web.socket.WebSocketSession;
 @Component
 public class SlackBot extends Bot {
 
+    /**
+     * The entry point to the spring integration process.
+     */
     private final InternalTranslationPort internalPort;
 
-    SlackBot( final InternalTranslationPort anInternalPort ) {
+    /**
+     * The service responsible for interactions with user data.
+     */
+    private final UserPort userService;
+
+    /**
+     * Manages Slack API calls.
+     */
+    private final SlackApiPort slackApiPort;
+
+    SlackBot( final InternalTranslationPort anInternalPort, final UserPort aUserService, final SlackApiPort aSlackApiPort ) {
         internalPort = anInternalPort;
+        userService = aUserService;
+        slackApiPort = aSlackApiPort;
     }
 
     @Value( "${slackBotToken}" )
@@ -30,6 +48,8 @@ public class SlackBot extends Bot {
             reply( session, event, new Message( "Hi, I am " + slackService.getCurrentUser().getName() ) );
         }
         else {
+            final User user = slackApiPort.getUser( event.getUserId() );
+            userService.save( user );
             CustomizedSentence inputSentence = new CustomizedSentence();
             inputSentence.setOriginalSentence( event.getText() );
             inputSentence.setUserExternalCode( event.getUserId() );

--- a/src/main/java/com/vacation_bot/gateway/outbound/slack/SlackApiGateway.java
+++ b/src/main/java/com/vacation_bot/gateway/outbound/slack/SlackApiGateway.java
@@ -1,0 +1,69 @@
+package com.vacation_bot.gateway.outbound.slack;
+
+import com.vacation_bot.shared.logging.AbstractLoggingAware;
+import com.vacation_bot.shared.logging.VacationBotLoggingMessages;
+import com.vacation_bot.spring.exception.NoUserFoundException;
+import me.ramswaroop.jbot.core.slack.models.User;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestOperations;
+
+/**
+ * The gateway that manages the outbound iterations with Slack API.
+ */
+@Component
+public class SlackApiGateway extends AbstractLoggingAware implements SlackApiPort {
+
+    @Value( "${slackBotToken}" )
+    private String slackToken;
+
+    /**
+     * Endpoint for Slack Api
+     */
+    @Value( "${slackApi}" )
+    private String slackApi;
+
+    /**
+     * Manages interactions through REST.
+     */
+    private final RestOperations restTemplate;
+
+    public SlackApiGateway( final RestOperations aRestTemplate ) {
+        restTemplate = aRestTemplate;
+    }
+
+    @Override
+    public User getUser( final String userId ) {
+        final String path = getUserConnectApi() + "&user=" + userId;
+        final ResponseEntity<UserResponse> response = restTemplate.getForEntity( path, UserResponse.class );
+        final User retrievedUser = response.getBody().getUser();
+        if ( retrievedUser == null ) {
+            getLogger().error( VacationBotLoggingMessages.USER_NOT_FOUND.getMessage(), response.getBody().getError() );
+            throw new NoUserFoundException( response.getBody().getError() );
+        }
+        return retrievedUser;
+    }
+
+    private String getUserConnectApi() {
+        return slackApi + "/users.info?token=" + slackToken;
+    }
+
+    public static class UserResponse {
+        private boolean ok;
+        private User user;
+        private String error;
+
+        public boolean isOk() {
+            return ok;
+        }
+
+        public User getUser() {
+            return user;
+        }
+
+        public String getError() {
+            return error;
+        }
+    }
+}

--- a/src/main/java/com/vacation_bot/gateway/outbound/slack/SlackApiPort.java
+++ b/src/main/java/com/vacation_bot/gateway/outbound/slack/SlackApiPort.java
@@ -1,0 +1,16 @@
+package com.vacation_bot.gateway.outbound.slack;
+
+import com.vacation_bot.spring.exception.NoUserFoundException;
+import me.ramswaroop.jbot.core.slack.models.User;
+
+public interface SlackApiPort {
+
+    /**
+     * Retrieves the user from the Slack API.
+     * Hope it'll be fixed in the next releases of jbot library and will be supported out of box.
+     * @param userId the unique identifier of the user that should be retrieved from slack.
+     * @return the found user.
+     * @throws {@link NoUserFoundException} if no user are retrieved.
+     */
+    User getUser( String userId );
+}

--- a/src/main/java/com/vacation_bot/shared/logging/VacationBotLoggingMessages.java
+++ b/src/main/java/com/vacation_bot/shared/logging/VacationBotLoggingMessages.java
@@ -8,7 +8,8 @@ public enum VacationBotLoggingMessages {
     STAGE_LOGGING( "The {} stage!" ),
     CLASSIFICATION_RESULT( "The classification result is {}" ),
     REGISTER_VACATION_CHAIN( "The chain of processing request vacation sentence class" ),
-    DAYS_LEFT_CHAIN( "The chain of processing days left request" );
+    DAYS_LEFT_CHAIN( "The chain of processing days left request" ),
+    USER_NOT_FOUND( "The user was not found. Message details: {}." );
 
     private String message;
 

--- a/src/main/java/com/vacation_bot/spring/exception/NoUserFoundException.java
+++ b/src/main/java/com/vacation_bot/spring/exception/NoUserFoundException.java
@@ -1,0 +1,11 @@
+package com.vacation_bot.spring.exception;
+
+/**
+ * Throw this exception for user retrieving operation.
+ */
+public class NoUserFoundException extends RuntimeException {
+
+    public NoUserFoundException( String message ) {
+        super( message );
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 rtmUrl=https://slack.com/api/rtm.start?token={token}&simple_latest&no_unreads
 slackBotToken=<your-secure-token>
+slackApi=https://slack.com/api

--- a/src/test/groovy/com/vacation_bot/core/process/RegisterVacationServiceUnitTest.groovy
+++ b/src/test/groovy/com/vacation_bot/core/process/RegisterVacationServiceUnitTest.groovy
@@ -18,8 +18,8 @@ import spock.lang.Unroll
 class RegisterVacationServiceUnitTest extends AbstractSpockUnitTest {
 
     def inputUserName = 'Alex'
-    def inputStartDate = '2017-10-02'
-    def inputEndDate = '2017-10-20'
+    def inputStartDate = '02.10.17'
+    def inputEndDate = '20.10.17'
 
     @Shared
     def validUser = Optional.of( new UserModel( id: '1', name: 'Alex', email: 'alex@mail.com' ) )
@@ -43,7 +43,7 @@ class RegisterVacationServiceUnitTest extends AbstractSpockUnitTest {
         def result = sut.registerVacation( new CustomizedSentence( persons: [inputUserName], dates: [inputStartDate, inputEndDate] ) )
 
         then: 'repositories return expected values'
-        1 * userModelRepository.findByNameOrAliases( inputUserName, inputUserName ) >> user
+        1 * userModelRepository.findById( inputUserName ) >> user
         1 * vacationTotalRepository.findByUserIdAndYear( user.get().id, Calendar.getInstance().get( Calendar.YEAR ) ) >> vacationTotal
 
         and: 'documents are saved to the database as expected'

--- a/src/test/groovy/com/vacation_bot/core/process/RequestDaysLeftServiceUnitTest.groovy
+++ b/src/test/groovy/com/vacation_bot/core/process/RequestDaysLeftServiceUnitTest.groovy
@@ -33,10 +33,10 @@ class RequestDaysLeftServiceUnitTest extends AbstractSpockUnitTest {
         def customizationSentence = new CustomizedSentence( persons: [inputUserName] )
 
         when: 'the exercised method is called'
-        def result = sut.calcuateDaysLeft( customizationSentence )
+        def result = sut.calculateDaysLeft( customizationSentence )
 
         then: 'the use is retrieved from the system'
-        1 * userModelRepository.findByNameOrAliases( inputUserName, inputUserName ) >> validUser
+        1 * userModelRepository.findById( inputUserName ) >> validUser
 
         and: 'the totals are retrieved from the system'
         1 * vacationTotalRepository.findByUserIdAndYear( validUser.get().id, Calendar.getInstance().get( Calendar.YEAR ) ) >> validVacationTotal


### PR DESCRIPTION
Previously there was a problem that I wasn't able to retrieve user information from `event` that jbot library provided in it's api. It's really the library problem so I fixed it by retrieving user information with the separate call to the Slack API (look into `SlackApiGateway`). Hope this could be removed after they'll fix the library api. 
Also added some minor fixes. Now bot is able to register a vacation and answer how many vacation days you still have. It's a very minimal working version.