### PR TITLE
Moved the creation of vacation total record to first user messaging

### DIFF
--- a/src/main/java/com/vacation_bot/VacationBotApplication.java
+++ b/src/main/java/com/vacation_bot/VacationBotApplication.java
@@ -12,6 +12,7 @@ import com.vacation_bot.core.services.UserService;
 import com.vacation_bot.core.validation.RegisterVacationValidator;
 import com.vacation_bot.core.validation.RequestVacationListValidator;
 import com.vacation_bot.core.words.WordsService;
+import com.vacation_bot.gateway.outbound.slack.SlackApiPort;
 import com.vacation_bot.repositories.DefaultRepositoryFactory;
 import com.vacation_bot.repositories.RepositoryFactory;
 import com.vacation_bot.shared.ApplicationProperties;
@@ -70,8 +71,8 @@ public class VacationBotApplication {
 	}
 
 	@Bean
-	public UserPort userPort( RepositoryFactory repositoryFactory ) {
-		return new UserService( repositoryFactory );
+	public UserPort userPort( RepositoryFactory repositoryFactory, SlackApiPort slackApiPort ) {
+		return new UserService( repositoryFactory, slackApiPort );
 	}
 
 	@Bean

--- a/src/main/java/com/vacation_bot/core/process/RegisterVacationService.java
+++ b/src/main/java/com/vacation_bot/core/process/RegisterVacationService.java
@@ -25,11 +25,6 @@ import java.util.UUID;
  */
 public class RegisterVacationService extends BaseService {
 
-    /**
-     * The default total vacation days.
-     */
-    private static final int DEFAULT_VACATION_TOTAL_DAYS = 20;
-
     public RegisterVacationService( RepositoryFactory factory ) {
         super( factory );
     }
@@ -53,15 +48,7 @@ public class RegisterVacationService extends BaseService {
                 .orElseThrow( () -> new RepositoryException( SharedConstants.USER_NOT_FOUND_MESSAGE ) );
 
         final VacationTotalModel vacationTotal = getVacationTotalRepository().findByUserIdAndYear( user.getId(), currentYear );
-        if ( vacationTotal == null ) {
-            VacationTotalModel newVacationTotal = new VacationTotalModel();
-            newVacationTotal.setUserId( user.getId() );
-            newVacationTotal.setVacationTotal( DEFAULT_VACATION_TOTAL_DAYS );
-            newVacationTotal.setYear( currentYear );
-            return compareVacationDaysAndReservedDays( newVacationTotal, user, startDate, endDate, period );
-        } else {
-            return compareVacationDaysAndReservedDays( vacationTotal, user, startDate, endDate, period );
-        }
+        return compareVacationDaysAndReservedDays( vacationTotal, user, startDate, endDate, period );
     }
 
     private String compareVacationDaysAndReservedDays( final VacationTotalModel vacationTotal,

--- a/src/main/java/com/vacation_bot/core/services/UserPort.java
+++ b/src/main/java/com/vacation_bot/core/services/UserPort.java
@@ -1,5 +1,6 @@
 package com.vacation_bot.core.services;
 
+import com.vacation_bot.domain.models.UserModel;
 import me.ramswaroop.jbot.core.slack.models.User;
 
 /**
@@ -10,6 +11,15 @@ public interface UserPort {
     /**
      * Saves user to the system.
      * @param user the user to save.
+     * @return saved user.
      */
-    void save( final User user );
+    UserModel save( final User user );
+
+    /**
+     * Returns the user from the system.
+     * If user doesn't exist in the system yet, it will be created.
+     * @param userId the user unique identifier.
+     * @return the user model.
+     */
+    UserModel getUser(final String userId );
 }

--- a/src/main/java/com/vacation_bot/core/services/UserService.java
+++ b/src/main/java/com/vacation_bot/core/services/UserService.java
@@ -2,24 +2,59 @@ package com.vacation_bot.core.services;
 
 import com.vacation_bot.core.BaseService;
 import com.vacation_bot.domain.models.UserModel;
+import com.vacation_bot.domain.models.VacationTotalModel;
+import com.vacation_bot.gateway.outbound.slack.SlackApiPort;
 import com.vacation_bot.repositories.RepositoryFactory;
 import me.ramswaroop.jbot.core.slack.models.User;
+
+import java.util.Calendar;
 
 /**
  * Responsible for managing user data.
  */
 public class UserService extends BaseService implements UserPort {
 
-    public UserService( final RepositoryFactory factory ) {
+    /**
+     * The default total vacation days.
+     */
+    private static final int DEFAULT_VACATION_TOTAL_DAYS = 20;
+
+    /**
+     * Manages Slack API calls.
+     */
+    private final SlackApiPort slackApiPort;
+
+    public UserService( final RepositoryFactory factory, final SlackApiPort aSlackApiPort ) {
         super( factory );
+        slackApiPort = aSlackApiPort;
     }
 
     @Override
-    public void save( final User user ) {
+    public UserModel save( final User user ) {
         final UserModel userModel = new UserModel();
         userModel.setId( user.getId() );
         userModel.setName( user.getName() );
         userModel.setEmail( user.getProfile().getEmail() );
-        getUserModelRepository().save( userModel );
+        return getUserModelRepository().save( userModel );
+    }
+
+    @Override
+    public UserModel getUser( final String userId ) {
+        return getUserModelRepository().findById( userId )
+                .orElseGet( () -> retrieveUserFromSlack(userId) );
+    }
+
+    private UserModel retrieveUserFromSlack( final String userId ) {
+        final User slackUser = slackApiPort.getUser( userId );
+        createInitialVacationTotal( userId );
+        return save( slackUser );
+    }
+
+    private void createInitialVacationTotal( final String userId ) {
+        VacationTotalModel initialVacationTotal = new VacationTotalModel();
+        initialVacationTotal.setUserId( userId );
+        initialVacationTotal.setVacationTotal( DEFAULT_VACATION_TOTAL_DAYS );
+        initialVacationTotal.setYear( Calendar.getInstance().get( Calendar.YEAR ) );
+        getVacationTotalRepository().save( initialVacationTotal );
     }
 }

--- a/src/test/groovy/com/vacation_bot/core/process/RegisterVacationServiceUnitTest.groovy
+++ b/src/test/groovy/com/vacation_bot/core/process/RegisterVacationServiceUnitTest.groovy
@@ -56,6 +56,5 @@ class RegisterVacationServiceUnitTest extends AbstractSpockUnitTest {
         user        ||   vacationTotal        || expectToCreateVacation  |  expectedResult                                                                                                        | description
         validUser   ||   validVacationTotal1  || 0                       |  "You can not receive vacation. You have 15 days."                                                                     | 'with no vacation days left'
         validUser   ||   validVacationTotal2  || 1                       |  "The registration of your vacation from 2017-10-02 to 2017-10-20 was successfully completed! You have left 6 days"    | 'with happy path'
-        validUser   ||   null                 || 1                       |  "The registration of your vacation from 2017-10-02 to 2017-10-20 was successfully completed! You have left 1 days"    | 'with days left but with no totals in the database'
     }
 }

--- a/src/test/groovy/com/vacation_bot/core/services/UserServiceUnitTest.groovy
+++ b/src/test/groovy/com/vacation_bot/core/services/UserServiceUnitTest.groovy
@@ -1,0 +1,90 @@
+package com.vacation_bot.core.services
+
+import com.vacation_bot.AbstractSpockUnitTest
+import com.vacation_bot.domain.models.UserModel
+import com.vacation_bot.domain.models.VacationTotalModel
+import com.vacation_bot.gateway.outbound.slack.SlackApiPort
+import com.vacation_bot.repositories.DefaultRepositoryFactory
+import com.vacation_bot.repositories.UserModelRepository
+import com.vacation_bot.repositories.VacationTotalModelRepository
+import me.ramswaroop.jbot.core.slack.models.Profile
+import me.ramswaroop.jbot.core.slack.models.User
+import spock.lang.Shared
+
+/**
+ * Unit level testing of the {@link UserService}.
+ */
+class UserServiceUnitTest extends AbstractSpockUnitTest {
+
+    def vacationTotalRepository = Mock( VacationTotalModelRepository )
+    def userModelRepository = Mock( UserModelRepository )
+    def slackApi = Mock( SlackApiPort )
+    def factory = new DefaultRepositoryFactory( [vacationTotalRepository, userModelRepository] )
+    def sut = new UserService( factory, slackApi )
+
+    @Shared
+    def externalUser = new User( id: 'some-id',
+            name: 'my-name',
+            profile: new Profile( email: 'valid@gmail.com' ) )
+
+    @Shared
+    def internalUser = new UserModel( id: externalUser.id,
+            name: externalUser.name,
+            email: externalUser.profile.email )
+
+    def 'exercise user save'() {
+        when: 'the exercised method is called'
+        def result = sut.save( externalUser )
+
+        then: 'the repository is called as expected'
+        1 * userModelRepository.save( internalUser ) >> internalUser
+
+        and: 'the user is returned as expected'
+        result == internalUser
+    }
+
+    def 'exercise user retrieval with one existed in the system'() {
+        given: 'valid user id'
+        def userId = 'valid-user-id'
+
+        and: 'expected user model'
+        def expectedUser = new UserModel( id: userId )
+
+        when: 'the exercised method is called'
+        def result = sut.getUser( userId )
+
+        then: 'the repository is called as expected'
+        1 * userModelRepository.findById( userId ) >> Optional.of( expectedUser )
+
+        and: 'the user is returned as expected'
+        result == expectedUser
+    }
+
+    def 'exercise user retrieval with no one in the system'() {
+        given: 'valid user id'
+        def userId = 'valid-user-id'
+
+        and: 'the expected vacation record'
+        def vacationTotalRecord = new VacationTotalModel( userId: userId,
+                vacationTotal: UserService.DEFAULT_VACATION_TOTAL_DAYS,
+                year: Calendar.getInstance().get( Calendar.YEAR ) )
+
+        when: 'the exercised method is called'
+        def result = sut.getUser( userId )
+
+        then: 'the repository is called as expected'
+        1 * userModelRepository.findById( userId ) >> Optional.empty()
+
+        and: 'the external call is made as expected'
+        1 * slackApi.getUser( userId ) >> externalUser
+
+        and: 'the total vacation record is created in the system as expected'
+        1 * vacationTotalRepository.save( vacationTotalRecord )
+
+        and: 'the user is saved to the system'
+        1 * userModelRepository.save( internalUser ) >> internalUser
+
+        and: 'the user is returned as expected'
+        result == internalUser
+    }
+}


### PR DESCRIPTION
The vacation total record previously was created when user is asking for vacation registration. This caused the problem with invalid response when user asks about total days before asking for vacation registration.
That's why the creation of vacation total record is moved to the first user interaction with bot.